### PR TITLE
PATH for both shells

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,10 +18,11 @@ echo "Installing gisty"
 go install gisty
 echo "Installed gisty"
 
-
+export PATH=$PATH:`pwd`/bin
 if [ -f ~/.zshrc ]; then
     echo "export PATH=\$PATH:`pwd`/bin" >> ~/.zshrc     
-else
+fi
+if [ -f ~/.bashrc ]; then
     echo "export PATH=\$PATH:`pwd`/bin" >> ~/.bashrc 
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,7 +6,6 @@ command -v go >/dev/null 2>&1 || {
     exit 1;
 }
 
-OLD_GOPATH=$GOPATH
 export GOPATH=$GOPATH:`pwd`
 
 # intall dependencies


### PR DESCRIPTION
I had something in my ~/.zshrc, the eager-beaver rvm wrote something into it, but I never use zsh. This script forgot to append my .bashrc mistakenly. 
Also I need to start a new shell or load the rc by hand if PATH is not exported here.
